### PR TITLE
joker card removal logic

### DIFF
--- a/src/main/java/models/Game.java
+++ b/src/main/java/models/Game.java
@@ -16,9 +16,10 @@ public class Game {
 
     public java.util.List<Column> cols = new ArrayList<>(4);
     public int points = 0;
-    public int canRemove; //0 = Cant remove, 1 = Can Remove, 2 = Column Empty
+    public int canRemove; //0 = Cant remove, 1 = Can Remove, 2 = Column Empty, 3 = trying to remove joker
     public int canMove;   //0 = Cant move, 1 = Can Move, 2 = Only Aces can move, 3 = Column empty
     public int wonGame = 0;
+    public int removedJoker = 0; //used for the case where there are 2 jokers in play
     public static int gameModeSet; /*GameModes -- 0-Regular, 1-Aces, 2-Spanish, 3-NoSelection*/
     public static void updateGameMode() {
       gameModeSet = ApplicationController.gameModeNum;
@@ -35,7 +36,7 @@ public class Game {
         if(gameModeSet == 0 || gameModeSet == 1){
             deck = new RegularDeck();
         }
-        else if(gameModeSet == 2){
+        else if(gameModeSet == 2) {
             deck = new SpanishDeck();
         }
     }
@@ -68,36 +69,89 @@ public class Game {
         this.cols.get(3).addCard(deck.cards.get(c4));
         deck.cards.remove(c4);
     }
-
-    public void remove(int columnNumber) {
-      // remove the top card from the indicated column
-      canRemove = 0;
-      if(!cols.get(columnNumber).hasCards()){
-        canRemove = 2;
-      } else {
-      for(int i = 0; i < this.cols.size(); i++){                    //check the card to remove against all other top cards
-          if(cols.get(i).hasCards() && cols.get(columnNumber).hasCards()) {
-              Card cardToRemove = cols.get(columnNumber).topCard();
-              Card cardToCheck = cols.get(i).topCard();
-
-              if(i != columnNumber && cardToRemove.suit == cardToCheck.suit && cardToRemove.value < cardToCheck.value) {  //if a higher card with matching suit
-                  canRemove = 1;                                        //set remove flag
-              }
-          }
-      }
+    //deals 2 jokers, and a 2 of coin, and a 5 of coin for testing purposes
+    public void customDealJokers() {
+        this.cols.get(0).addCard(new SpanishCard(1, Suit.Joker));
+        this.cols.get(1).addCard(new SpanishCard(2, Suit.Joker));
+        this.cols.get(2).addCard(new SpanishCard(2, Suit.Coin));
+        this.cols.get(3).addCard(new SpanishCard(5, Suit.Coin));
     }
 
-      if(canRemove == 1) {           //remove card if flag is set
-          cols.get(columnNumber).removeCard();
-          points++;
-          if(points >= 48 && (gameModeSet == 0 || gameModeSet == 1)){            //in regular modes, 48 points is required
-            wonGame = 1;
-          }
-          else if(points >= 46 && gameModeSet == 2){                           //in spanish mode, 46 points is required
-              wonGame = 1;
-          }
-      }
-  }
+
+    public void remove(int columnNumber) {
+        // remove the top card from the indicated column
+        if(gameModeSet == 0 || gameModeSet == 1) {
+            canRemove = 0;
+            if (!cols.get(columnNumber).hasCards()) {
+                canRemove = 2;
+            } else {
+                for (int i = 0; i < this.cols.size(); i++) {                    //check the card to remove against all other top cards
+                    if (cols.get(i).hasCards()) {
+                        Card cardToRemove = cols.get(columnNumber).topCard();
+                        Card cardToCheck = cols.get(i).topCard();
+
+                        if (i != columnNumber && cardToRemove.suit == cardToCheck.suit && cardToRemove.value < cardToCheck.value) {  //if a higher card with matching suit
+                            canRemove = 1;                                        //set remove flag
+                        }
+                    }
+                }
+            }
+        }else if (gameModeSet == 2) {
+            canRemove = 0;
+            removedJoker = 0;
+            if (!cols.get(columnNumber).hasCards()) {
+                //error, the column is empty
+                canRemove = 2;
+                //if it's not empty then we do our regular checks
+            } else {
+                Card checkJoker = cols.get(columnNumber).topCard();
+                //then check to see if it's a joker
+                if(checkJoker.suit.toString() == "Joker") {
+                    //if it's a joker then you can't remove that card!
+                    canRemove = 3; // mark as a joker
+                }
+                //if not a joker, and column not empty
+                if(canRemove == 0) {
+                    //standard removal checking.
+                    for (int i = 0; i < this.cols.size(); i++) { // loop through columns
+                        if (cols.get(i).hasCards()) {//if the column has cards
+                            Card cardToRemove = cols.get(columnNumber).topCard();
+                            Card cardToCheck = cols.get(i).topCard();
+                            // if suit is matching, and column is different and value is less then remove it
+                            if (i != columnNumber && cardToRemove.suit == cardToCheck.suit && cardToRemove.value < cardToCheck.value) {
+                                canRemove = 1;
+                            }
+                        }
+                    }
+                    //loop through one more time this time checking for jokers to remove the card
+                    if (canRemove == 0) {
+                        for (int i = 0; i < this.cols.size(); i++) { // loop through columns again
+                            if (cols.get(i).hasCards()) {
+                                Card cardToRemove = cols.get(columnNumber).topCard();
+                                Card cardToCheck = cols.get(i).topCard();
+                                //if there's a joker then let's consider that it can be removed regardless.
+                                if ((cardToCheck.suit.toString() == "Joker") && (i != columnNumber) && (removedJoker == 0)) {
+                                    canRemove = 1; // we can remove our card
+                                    removedJoker = 1; //tag our joker as removed so the next loop through will not remove another
+                                    cols.get(i).removeCard(); // remove the joker as well, but no points awarded
+                                }
+                            }
+                        }
+                    }//end of if
+                }
+            }//end of else
+        }//end of else if
+        if (canRemove == 1) {           //remove card if flag is set
+            cols.get(columnNumber).removeCard();
+            points++;
+            if (points >= 48 && (gameModeSet == 0 || gameModeSet == 1)) {            //in regular modes, 48 points is required
+                wonGame = 1;
+            } else if (points >= 46 && gameModeSet == 2) {                           //in spanish mode, 46 points is required
+                wonGame = 1;
+            }
+        }
+
+    }
 
     public void move(int columnFrom, int columnTo) {
       if(gameModeSet == 0 || gameModeSet == 2){

--- a/src/main/java/views/AcesUp/AcesUp.flt.html
+++ b/src/main/java/views/AcesUp/AcesUp.flt.html
@@ -185,6 +185,8 @@ function removedNotice(){
          document.getElementById("errorMessage").innerHTML = "Can't remove card!";
        } else if (game.canRemove == 2){
          document.getElementById("errorMessage").innerHTML = "Column is Empty!";
+       } else if (game.canRemove == 3){
+         document.getElementById("errorMessage").innerHTML = "Can't remove joker!";
        }
    }
  }

--- a/src/test/java/models/testGame.java
+++ b/src/test/java/models/testGame.java
@@ -104,6 +104,27 @@ public class testGame {
         assertEquals(2,g.canRemove);      //remove from column 0 unsuccessful, column is empty
         g.remove(3);
         assertEquals(0,g.canRemove);      //remove from column 3 unsuccessful, no higher card of same suit
+        // set game mode to 2 and run test for remove again
+        ApplicationController.gameModeNum = 2;
+        Game e = new Game();
+        e.customDeal(0, 3, 6, 9);
+        e.remove(0);
+        assertEquals(1,e.canRemove);      //remove from column 0 successful
+        e.remove(0);
+        assertEquals(2,e.canRemove);      //remove from column 0 unsuccessful, column is empty
+        e.remove(3);
+        assertEquals(0,e.canRemove);      //remove from column 3 unsuccessful, no higher card of same suit
+        ApplicationController.gameModeNum = 2;
+        Game f = new Game();
+        f.customDealJokers();
+        f.remove(0);
+        assertEquals(3, f.canRemove);     //remove from column 0 unsuccessful (joker in place)
+        f.remove(1);
+        assertEquals(3, f.canRemove);     //remove from column 1 unsuccessful (joker in place)
+        f.remove(2);
+        assertEquals(1, f.canRemove);     //remove from column 2 successful (higher number in play)
+        f.remove(3);
+        assertEquals(1, f.canRemove);     //remove from column 3 successful (joker on field)
     }
 
     @Test


### PR DESCRIPTION
added logic to deal with removing cards in spanish deck and dealing with joker logic, as well as added test cases for jokers, and added an error message when trying to remove a joker directly

interactions with jokers is as follows:
**with 0 jokers on the field of play:**
- cards are removed based on suits and values only, like normal. One point is awarded

**with 1 joker on the field of play:**
- cards are first removed based on suits and values only, like normal. One point is awarded.
- If there is no matching suit on the field of play with a value that is higher, then the game will remove the selected card and the joker. One point is awarded.
- If there are 2 cards of the same suit, and the player selects to remove the card of higher suit, it will remove that card, and remove the joker from play. The lower suit card will remain. One point is awarded.

**with 2 jokers on the field of play:**
- cards are first removed based on suits and values only, like normal. One point is awarded.
- if there are matching suits and the higher valued card is selected for removal, the card will be removed along with one joker. One point is awarded
- if a user tries to remove one joker, an error message will say you cannot remove the joker. No cards will be removed from the field of play. No points awarded.
